### PR TITLE
Added environment var usage

### DIFF
--- a/server/src/db/db.js
+++ b/server/src/db/db.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const mongoose = require('mongoose');
 const FighterModel = require('./models/fighter');
 const MatchModel = require('./models/match');

--- a/server/src/saltylog.js
+++ b/server/src/saltylog.js
@@ -1,10 +1,11 @@
 // Responsible for picking out the relevant data and forwarding
 // It to be submitted to the DB
+require('dotenv').config();
 const tmi = require('tmi.js');
 const db = require('./db/db.js');
 
-const channelName = 'saltybet';
-const refBotName = 'WAIFU4u';
+const channelName = process.env.CHANNEL;
+const refBotName = process.env.REF_BOT;
 
 // strings for identifying when to process a message
 const openMatchStr = 'Bets are OPEN';


### PR DESCRIPTION
Added use of environment vars CHANNEL and REF_BOT
This allows for easier testing as we can put custom messages in our own twitch channel instead of waiting for saltybet to produce the scenarios we want

NOTE: This requires a change to the .env file in production